### PR TITLE
Changed dates format for two publications

### DIFF
--- a/dist/docs/a_publication_taxonomy/a-publication-taxonomy.html
+++ b/dist/docs/a_publication_taxonomy/a-publication-taxonomy.html
@@ -12,7 +12,7 @@
     <META NAME="DC.creator" CONTENT="Loraine Furter, Simon Worthington">
     <META NAME="DC.subject" CONTENT="taxonomy, open access, academic publishing">
     <META NAME="DC.description.abstract" CONTENT="copy of description">
-    <META NAME="DC.date" CONTENT="01.01.14">
+    <META NAME="DC.date" CONTENT="2014-01-01">
     <META NAME="DC.type" CONTENT="Book">
     <META NAME="DC.format" CONTENT="text/html">
     <META NAME="DC.language" CONTENT="en">

--- a/dist/docs/traces_on_the_archive/traces_on_the_archive.html
+++ b/dist/docs/traces_on_the_archive/traces_on_the_archive.html
@@ -8,7 +8,7 @@
 <META NAME="DC.creator" CONTENT="Simon Worthington">
 <META NAME="DC.subject" CONTENT="keywords, key phrases, or classification codes, best using controlled vocabularies">
 <META NAME="DC.description.abstract" CONTENT="A research case study focused on traces on the archive, revealing the hidden journey of a user through an archive, based on the Marshall McLuhan collection at the McLuhan Salon, Canadian Embassy, Berlin">
-<META NAME="DC.date" CONTENT="30.04.2015">
+<META NAME="DC.date" CONTENT="2015-04-30">
 <META NAME="DC.type" CONTENT="Research Report">
 <META NAME="DC.format" CONTENT="text/html">
 <META NAME="DC.language" CONTENT="en">


### PR DESCRIPTION
‘A Publication Taxonomy’ and ‘Traces on the Archive’ had their Dublin Core dates formatted as dd.mm.yy and dd.mm.yyyy respectively, while all the other publications are yyyy-mm-dd (ISO 8601). Updated their DC.date so they all match.
